### PR TITLE
Add iceoryx2 and rmw_iceoryx2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ List of (awesome) Rust libraries for Robotics. If you know something awesome (or
 * [rosbag](https://github.com/SkoltechRobotics/rosbag-rs) - Reading rosbag files in pure Rust
 * [rustros_tf](https://github.com/arjo129/rustros_tf) - A rust implementation of the Tf library.
 * [ros_pointcloud2](https://github.com/stelzo/ros_pointcloud2) - The safe way of using PointCloud2 messages in ROS1 and ROS2.
+* [rmw_iceoryx2](https://github.com/ekxide/rmw_iceoryx2) - A ROS 2 RMW implementation based on iceoryx2
 * [optimization-engine](https://alphaville.github.io/optimization-engine/) - Fast & Accurate Embedded Optimization for next-generation Robotics and Autonomous Systems
 * [safe_drive](https://github.com/tier4/safe_drive) - safe_drive: Formally Specified Rust Bindings for ROS2
 * [transforms](https://github.com/deniz-hofmeister/transforms) - A minimal and stand-alone crate inspired by the ROS2 tf library, but not dependent on ROS or middleware
@@ -27,6 +28,7 @@ List of (awesome) Rust libraries for Robotics. If you know something awesome (or
 
 * [copper](https://github.com/copper-project/copper-rs) - Copper is a user-friendly robotics framework designed for creating fast and reliable robots. Copper is to robots what a game engine is to games.
 * [dora-rs](https://github.com/dora-rs/dora) - A fast and simple robotics frameworks for AI.
+* [iceoryx2](https://github.com/eclipse-iceoryx/iceoryx2) - A true zero-copy inter-process communication middleware with a sub microsecond latency for safety-critical applications
 * [OpenRR](https://github.com/openrr/openrr) - Open Rust Robotics
 * [Zenoh](https://zenoh.io) - A high performance and extremely low overhead Pub/Sub/Query protocol. Quickly becoming the protocol of choice for Robot-to-Anything communication. 
 * [Peng](https://github.com/makeecat/Peng) - A minimal quadrotor autonomy framework


### PR DESCRIPTION
Adds iceoryx2 and rmw_iceoryx2 to the readme.

The predecessor of iceoryx2, iceoryx classic is used in Cyclone DDS, which also has a RMW implementation. Additionally, [AimRT](https://aimrt.org/) also has an iceoryx classic plugin.

iceoryx2 is the successor of iceoryx classic, written in Rust with an improved architecture and language bindings vor C, C++ and Python. 

I noticed that the entries are mostly ordered alphabetically, but I was hesitant to put rmw_iceoryx2 at the top of the ROS section myself.

Closes #42 